### PR TITLE
1.2.1 Front Page Parity Fix (Alternating Rows) (vibe-kanban)

### DIFF
--- a/style.css
+++ b/style.css
@@ -430,3 +430,45 @@ body > footer {
     height: auto;
     margin-bottom: 2rem;
 }
+
+/*--------------------------------------------------------------
+# Block Theme Styles (Front Page Parity)
+--------------------------------------------------------------*/
+.work-loop {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.work-row {
+    display: flex;
+    gap: 2rem;
+    align-items: center;
+    padding: 3rem 0;
+    border-bottom: 1px solid #eee;
+}
+
+.work-loop > li:first-child .work-row {
+    border-top: 1px solid #eee;
+}
+
+.work-text {
+    flex: 1;
+}
+
+.work-image {
+    flex: 1;
+}
+
+/* The magic: reverse the order on even rows */
+@media (min-width: 1024px) {
+    .work-loop > li:nth-child(even) .work-row {
+        flex-direction: row-reverse;
+    }
+}
+
+@media (max-width: 768px) {
+    .work-row {
+        flex-direction: column;
+    }
+}

--- a/templates/front-page.html
+++ b/templates/front-page.html
@@ -1,53 +1,31 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:cover {"url":"http://nano-design-build-v1.test/wp-content/uploads/2025/07/250705-NanoGreenDot-NanoBackgroundVideo.mp4","id":1,"dimRatio":50,"minHeight":100,"minHeightUnit":"vh","contentPosition":"center center","isDark":false} -->
-<div class="wp-block-cover" style="min-height:100vh">
-    <span aria-hidden="true" class="wp-block-cover__background-container">
-        <video class="wp-block-cover__video-background" autoplay muted loop src="http://nano-design-build-v1.test/wp-content/uploads/2025/07/250705-NanoGreenDot-NanoBackgroundVideo.mp4" poster="YOUR_POSTER_IMAGE_URL.jpg"></video>
-    </span>
-    <div class="wp-block-cover__inner-container">
-        <!-- wp:group {"layout":{"type":"constrained"}} -->
-        <div class="wp-block-group">
-            <!-- wp:heading {"textAlign":"center","level":1,"style":{"typography":{"fontSize":"4rem"}}} -->
-            <h1 class="has-text-align-center" style="font-size:4rem">Designing & Building The Future</h1>
-            <!-- /wp:heading -->
-            <!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"1.5rem"}}} -->
-            <p class="has-text-align-center" style="font-size:1.5rem">We craft bespoke homes that merge timeless design with modern living.</p>
-            <!-- /wp:paragraph -->
-        </div>
-        <!-- /wp:group -->
-    </div>
-</div>
-<!-- /wp:cover -->
+<!-- wp:group {"className":"container","layout":{"type":"constrained"}} -->
+<div class="wp-block-group container">
+    <!-- wp:post-content /-->
 
-<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|80"}}},"layout":{"type":"constrained"}} -->
-<main class="wp-block-group" style="padding-top:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--80)">
-    <!-- wp:heading {"textAlign":"center"} -->
-    <h2 class="has-text-align-center">Recent Work</h2>
-    <!-- /wp:heading -->
-
-    <!-- wp:query {"queryId":1,"query":{"perPage":3,"pages":0,"offset":0,"postType":"project","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
-    <div class="wp-block-query">
+    <!-- wp:query {"queryId":1,"query":{"perPage":3,"pages":0,"offset":0,"postType":"project","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"className":"work-loop"} -->
+    <div class="wp-block-query work-loop">
         <!-- wp:post-template -->
-            <!-- wp:post-featured-image {"isLink":true} /-->
-            <!-- wp:post-title {"isLink":true} /-->
-            <!-- wp:post-excerpt /-->
-            <!-- wp:post-terms {"term":"location"} /-->
+        <!-- wp:columns {"className":"work-row"} -->
+        <div class="wp-block-columns work-row">
+            <!-- wp:column {"className":"work-text"} -->
+            <div class="wp-block-column work-text">
+                <!-- wp:post-title {"isLink":true} /-->
+                <!-- wp:post-excerpt /-->
+            </div>
+            <!-- /wp:column -->
+            <!-- wp:column {"className":"work-image"} -->
+            <div class="wp-block-column work-image">
+                <!-- wp:post-featured-image {"isLink":true,"align":""} /-->
+            </div>
+            <!-- /wp:column -->
+        </div>
+        <!-- /wp:columns -->
         <!-- /wp:post-template -->
     </div>
     <!-- /wp:query -->
-
-    <!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center"}} -->
-    <div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--60)">
-        <!-- wp:image {"width":32,"height":32,"sizeSlug":"full","linkDestination":"none"} -->
-        <figure class="wp-block-image size-full is-resized"><img src="/wp-content/themes/nano-design-build/images/nano.svg" alt="Nano Design Build Logo" width="32" height="32"/></figure>
-        <!-- /wp:image -->
-        <!-- wp:paragraph -->
-        <p><a href="/projects">View All Projects</a></p>
-        <!-- /wp:paragraph -->
-    </div>
-    <!-- /wp:group -->
-</main>
+</div>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->


### PR DESCRIPTION
{
  "task_id": "1.2.1",
  "task_title": "Front Page Parity Fix (Alternating Rows)",
  "objective": "Make templates/front-page.html render the same alternating image/text rows as the approved PHP version.",
  "constraints": [
    "Do not add theme.json yet.",
    "Use only core blocks: Group, Columns, Query Loop, Post Title, Post Excerpt, Featured Image.",
    "Keep existing PHP files for reference."
  ],
  "requirements": [
    "Wrap the front page in a top-level Group with className \"container\" (or the exact class your CSS expects) so content is not full-width.",
    "Place a Post Content block at the top so the intro/heading renders.",
    "Add a Query Loop limited to the 'project' CPT, newest first. The inner template must be: Columns(2) → [Text Column] Post Title, Post Excerpt, taxonomy/meta → [Image Column] Featured Image.",
    "Give the outer Post Template UL a className \"work-loop\"; give the Columns block a className \"work-row\"; give the two inner columns classNames \"work-text\" and \"work-image\".",
    "Ensure the Featured Image block has no 'align full' setting and respects column width.",
    "Navigation: if the header uses a Navigation block, ensure the 'primary' menu is assigned so the header isn’t empty."
  ],
  "acceptance_criteria": [
    "At 1024px+ width, rows alternate (row 1: text left / image right, row 2: image left / text right, etc.).",
    "No element extends full-bleed except where it did in PHP; overall width matches the PHP layout.",
    "Front page shows intro content above the list, as before.",
    "No console errors; screenshots attached showing before/after parity."
  ],
  "implementation_notes": [
    "Use CSS already in style.css by matching the original wrapper classNames. If alternation relied on nth-child, keep the same selectors (e.g., .work-loop > li:nth-child(even) .work-row { flex-direction: row-reverse; }).",
    "If the original CSS doesn’t exist, add minimal rules to style.css ONLY to restore alternation and column widths."
  ],
  "post_task_actions": [
    "Update README.md and changelog.",
    "Open PR: \"1.2.1 Front page parity (alternating rows)\" with screenshots."
  ]
}
