### PR TITLE
1.2.1 — Front Page Parity Fix (HTML Hero + Portfolio Skeleton) (vibe-kanban)

### DIFF
--- a/style.css
+++ b/style.css
@@ -430,3 +430,8 @@ body > footer {
     height: auto;
     margin-bottom: 2rem;
 }
+
+/*--------------------------------------------------------------
+# 1.2.1 - Front Page Parity Fix
+--------------------------------------------------------------*/
+.work-loop{list-style:none;margin:0;padding:0}.work-row{display:flex;align-items:center;gap:0}.work-text,.work-image{flex:1 1 50%}.work-row .wp-block-columns{gap:0} .work-link{display:inline-block;text-decoration:none;transition:color .2s ease,transform .2s ease,opacity .2s ease}.work-image img{display:block;transition:transform .25s ease,opacity .25s ease}.work-row:hover .work-image img{transform:translateY(-2px) scale(1.02);opacity:.96}.work-row:hover .work-text h2{text-decoration:underline}

--- a/templates/front-page.html
+++ b/templates/front-page.html
@@ -2,69 +2,44 @@
 
 <!-- wp:group {"tagName":"main","layout":{"type":"default"}} -->
 <main>
-	<!-- wp:cover {"url":"/wp-content/uploads/2025/07/placeholder-image.jpg","dimRatio":50,"overlayColor":"black","contentPosition":"center center","isDark":false,"align":"full","className":"hero-video-section"} -->
-	<div class="wp-block-cover alignfull is-light hero-video-section">
-		<span aria-hidden="true" class="wp-block-cover__background has-black-background-color has-background-dim-50 has-background-dim"></span>
-		<img class="wp-block-cover__image-background" alt="" src="/wp-content/uploads/2025/07/placeholder-image.jpg" data-object-fit="cover"/>
-		<div class="wp-block-cover__inner-container">
-			<!-- wp:html -->
-			<video playsinline autoplay muted loop class="hero-video-bg">
-				<source src="/wp-content/uploads/2025/07/250705-NanoGreenDot-NanoBackgroundVideo.mp4" type="video/mp4">
-			</video>
-			<!-- /wp:html -->
-			<!-- wp:group {"className":"hero-content","layout":{"type":"constrained"}} -->
-			<div class="hero-content">
-				<!-- wp:heading {"level":1,"className":"hero-title"} -->
-				<h1 class="hero-title">Designing & Building The Future</h1>
-				<!-- /wp:heading -->
-				<!-- wp:paragraph {"className":"hero-subtitle"} -->
-				<p class="hero-subtitle">We craft bespoke homes that merge timeless design with modern living.</p>
-				<!-- /wp:paragraph -->
+	<!-- wp:html -->
+<video class="hero-video-bg" playsinline autoplay muted loop src="/wp-content/uploads/2025/07/250705-NanoGreenDot-NanoBackgroundVideo.mp4"></video>
+<!-- /wp:html -->
+
+	<!-- wp:html -->
+<ul class="work-loop">
+	<li>
+		<div class="work-row">
+			<div class="work-text">
+				<a class="work-link" href="/project/placeholder-project-1/">
+					<h2>Project Title 1</h2>
+					<p>A brief description of the first project goes here. It highlights the key features and design philosophy.</p>
+				</a>
 			</div>
-			<!-- /wp:group -->
+			<div class="work-image">
+				<a class="work-link" href="/project/placeholder-project-1/">
+					<img src="/wp-content/uploads/2025/07/placeholder-thumb-1.jpg" alt="Placeholder image for Project 1" />
+				</a>
+			</div>
 		</div>
-	</div>
-	<!-- /wp:cover -->
-
-	<!-- wp:group {"className":"homepage-projects","layout":{"type":"constrained"}} -->
-	<div class="homepage-projects">
-		<!-- wp:heading {"level":2,"className":"section-title"} -->
-		<h2 class="section-title">Recent Work</h2>
-		<!-- /wp:heading -->
-
-		<!-- wp:query {"queryId":1,"query":{"perPage":3,"pages":0,"offset":0,"postType":"project","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"className":"project-archive-list"} -->
-		<div class="project-archive-list">
-			<!-- wp:post-template -->
-				<!-- wp:group {"className":"project-archive-item"} -->
-				<div class="project-archive-item">
-					<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"auto","className":"project-archive-image"} /-->
-					<!-- wp:group {"className":"project-archive-details"} -->
-					<div class="project-archive-details">
-						<!-- wp:post-title {"isLink":true,"className":"project-title"} /-->
-						<!-- wp:post-excerpt {"className":"project-excerpt"} /-->
-						<!-- wp:post-terms {"term":"location","className":"project-location-tag"} /-->
-					</div>
-					<!-- /wp:group -->
-				</div>
-				<!-- /wp:group -->
-			<!-- /wp:post-template -->
+	</li>
+	<li>
+		<div class="work-row">
+			<div class="work-text">
+				<a class="work-link" href="/project/placeholder-project-2/">
+					<h2>Project Title 2</h2>
+					<p>This is a short summary of the second project, emphasizing its unique architectural style and materials.</p>
+				</a>
+			</div>
+			<div class="work-image">
+				<a class="work-link" href="/project/placeholder-project-2/">
+					<img src="/wp-content/uploads/2025/07/placeholder-thumb-2.jpg" alt="Placeholder image for Project 2" />
+				</a>
+			</div>
 		</div>
-		<!-- /wp:query -->
-
-		<!-- wp:group {"className":"section-link","layout":{"type":"flex","justifyContent":"center"}} -->
-		<div class="section-link">
-			<!-- wp:image {"width":50,"height":50,"sizeSlug":"full","linkDestination":"none","className":"final-card-logo"} -->
-			<figure class="wp-block-image size-full is-resized final-card-logo">
-				<img src="/wp-content/themes/vibe-kanban/images/nano.svg" alt="Nano Design Build Logo" width="50" height="50"/>
-			</figure>
-			<!-- /wp:image -->
-			<!-- wp:paragraph -->
-			<p><a href="/projects">View All Projects</a></p>
-			<!-- /wp:paragraph -->
-		</div>
-		<!-- /wp:group -->
-	</div>
-	<!-- /wp:group -->
+	</li>
+</ul>
+<!-- /wp:html -->
 </main>
 <!-- /wp:group -->
 


### PR DESCRIPTION
{
  "task_id": "1.2.1",
  "task_title": "Front Page Parity Fix (Hero HTML block + Portfolio skeleton)",
  "objective": "Correct the 1.2.0 block front page to match the PHP layout/behaviors: hero video restored and portfolio rows alternate with hover effects, using the exact DOM/class hooks CSS expects.",
  "context": "1.2.0 introduced drift (full-width blocks, missing hovers, broken alternation). This task constrains markup to the PHP contract so existing CSS applies without redesign.",
  "constraints": [
    "Do not change server/DNS/DB settings.",
    "Do not add theme.json in this task.",
    "Use only core blocks; for hero/portfolio containers, prefer HTML blocks to preserve exact markup.",
    "All media URLs must be site-relative (/wp-content/...).",
    "Do not introduce alignwide/alignfull or extra wrappers that alter layout."
  ],
  "requirements": [
    "In templates/front-page.html, replace the current hero with an HTML block containing the exact video tag from PHP:",
    {
      "html_snippet_hero": "<video class=\"hero-video-bg\" playsinline autoplay muted loop src=\"/wp-content/uploads/.../NanoBackgroundVideo.mp4\"></video>"
    },
    "In templates/front-page.html, ensure the portfolio section uses the exact outer skeleton so CSS nth-child alternation works. Use an HTML block for the wrapper and repeat rows:",
    {
      "html_snippet_portfolio": "<ul class=\"work-loop\">\n  <li>\n    <div class=\"work-row\">\n      <div class=\"work-text\">\n        <a class=\"work-link\" href=\"PROJECT_URL\">\n          <h2>Project Title</h2>\n          <p>Short excerpt…</p>\n        </a>\n      </div>\n      <div class=\"work-image\">\n        <a class=\"work-link\" href=\"PROJECT_URL\">\n          <img src=\"/wp-content/uploads/.../thumb.jpg\" alt=\"…\" />\n        </a>\n      </div>\n    </div>\n  </li>\n</ul>"
    },
    "Non‑negotiables: The following classes must exist and wrap content exactly as shown: .work-loop, .work-row, .work-text, .work-image, .work-link. Both text and image must be inside .work-link anchors so hover CSS fires.",
    "Neutralize Gutenberg spacing within this front page if it leaks through. If needed, append the following minimal rules to style.css (or place adjacent to existing rules) without changing design tokens:",
    {
      "css_patch_optional": ".work-loop{list-style:none;margin:0;padding:0}.work-row{display:flex;align-items:center;gap:0}.work-text,.work-image{flex:1 1 50%}.work-row .wp-block-columns{gap:0} .work-link{display:inline-block;text-decoration:none;transition:color .2s ease,transform .2s ease,opacity .2s ease}.work-image img{display:block;transition:transform .25s ease,opacity .25s ease}.work-row:hover .work-image img{transform:translateY(-2px) scale(1.02);opacity:.96}.work-row:hover .work-text h2{text-decoration:underline}"
    },
    "Header/footer parts remain as in 1.2.0; do not change their wrappers or classes.",
    "Leave PHP templates in place for reference; do not delete."
  ],
  "acceptance_criteria": [
    "DOM/class parity: .hero-video-bg, .work-loop, .work-row, .work-text, .work-image, .work-link are present as in PHP.",
    "Hero video autoplays (muted, playsinline) and src is site-relative (no old domain).",
    "Portfolio rows alternate via existing CSS (nth-child) and hover effects trigger on both image and text.",
    "No console errors; no 404s for media; no alignwide/alignfull introduced.",
    "PR includes before/after screenshots showing parity on desktop."
  ],
  "file_scope": [
    "templates/front-page.html",
    "style.css (optional small patch only)",
    "(reference) front-page.php"
  ],
  "post_task_actions": [
    "Update README.md (status + changelog).",
    "Open PR: '1.2.1 Front page parity fix (HTML hero + portfolio skeleton)'."
  ]
}