### PR TITLE
Refine footer layout and brand accent usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,14 @@ This project is the development of a custom portfolio website for Nano Green Dot
 
 ## Brand Tokens
 
-* **Brand accent / highlight color:** `#ff931e` — Use for key accents such as icons, links, and highlight elements; avoid overuse.
+* **Brand accent / highlight color:** `#ff931e` — Use for key accents such as icons, links, and highlight elements; avoid overuse. This is the primary accent orange for Nano Design Build and should be applied to small emphasis elements (e.g., social icons, hover highlights, the © symbol in the footer) rather than large text blocks.
+
+## Footer layout (December 2025 refresh)
+
+* Left column: Nano logo plus the copyright line (© 2006–{current year} Nano Design Build) with the © symbol in `#ff931e`.
+* Middle column: contact details only (phone, address, email) without a “Contact” heading.
+* Right column: social icons in this order — LinkedIn, Instagram, Facebook, YouTube.
+* Footer padding and spacing have been tightened to reduce overall height while preserving readability across breakpoints.
 
 ---
 

--- a/footer.php
+++ b/footer.php
@@ -15,16 +15,21 @@
                         <?php bloginfo( 'name' ); ?>
                     </a>
                 <?php endif; ?>
+
+                <div class="footer-copyright" role="contentinfo">
+                    <span class="footer-copyright__symbol" aria-hidden="true">©</span>
+                    <span class="screen-reader-text">Copyright</span>
+                    <span class="footer-copyright__text">2006-<?php echo date('Y'); ?> Nano Design Build</span>
+                </div>
             </div>
 
             <!-- Contact info -->
             <div class="footer-column footer-column--contact">
-                <h4 class="footer-heading">Contact</h4>
                 <ul class="footer-contact">
-                    <li class="footer-contact__line">1670 Bayview Avenue, Suite 302, Toronto, ON, M4G 3C2</li>
                     <li class="footer-contact__line">
                         <a href="tel:4164883350">T: 416-488-3350</a>
                     </li>
+                    <li class="footer-contact__line">1670 Bayview Avenue, Suite 302, Toronto, ON, M4G 3C2</li>
                     <li class="footer-contact__line">
                         <a href="mailto:info@nanodesignbuild.com">info@nanodesignbuild.com</a>
                     </li>
@@ -35,21 +40,20 @@
             <div class="footer-column footer-column--social">
                 <div class="footer-social" aria-label="Social media">
                     <!-- TODO: Replace placeholder links with live profiles -->
-                    <a class="footer-social__link" href="#" aria-label="Instagram">
-                        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7 3h10a4 4 0 0 1 4 4v10a4 4 0 0 1-4 4H7a4 4 0 0 1-4-4V7a4 4 0 0 1 4-4Zm0 2a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2H7Zm5 2.5A4.5 4.5 0 1 1 7.5 12 4.5 4.5 0 0 1 12 7.5Zm0 2a2.5 2.5 0 1 0 2.5 2.5A2.5 2.5 0 0 0 12 9.5Zm5.25-2.75a.75.75 0 1 1-.75.75.75.75 0 0 1 .75-.75Z"/></svg>
-                    </a>
                     <a class="footer-social__link" href="#" aria-label="LinkedIn">
                         <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6.94 9.75V18H4.13V9.75h2.81ZM5.53 6a1.62 1.62 0 1 1 0 3.24 1.62 1.62 0 0 1 0-3.24ZM19.88 18h-2.8v-4.39c0-1.2-.43-1.98-1.52-1.98-.83 0-1.32.56-1.54 1.1-.08.2-.1.47-.1.74V18h-2.8s.04-7.53 0-8.25h2.8v1.17c.37-.57 1.03-1.38 2.51-1.38 1.83 0 3.23 1.2 3.23 3.77V18Z"/></svg>
                     </a>
-                    <a class="footer-social__link" href="#" aria-label="Houzz">
-                        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 3v18l7-3.5V13l7 3.5V3L12 6.5V11L5 7.5V3Z"/></svg>
+                    <a class="footer-social__link" href="#" aria-label="Instagram">
+                        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7 3h10a4 4 0 0 1 4 4v10a4 4 0 0 1-4 4H7a4 4 0 0 1-4-4V7a4 4 0 0 1 4-4Zm0 2a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2H7Zm5 2.5A4.5 4.5 0 1 1 7.5 12 4.5 4.5 0 0 1 12 7.5Zm0 2a2.5 2.5 0 1 0 2.5 2.5A2.5 2.5 0 0 0 12 9.5Zm5.25-2.75a.75.75 0 1 1-.75.75.75.75 0 0 1 .75-.75Z"/></svg>
+                    </a>
+                    <a class="footer-social__link" href="#" aria-label="Facebook">
+                        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M13.5 21h-3v-7H8v-2.7h2.5V9.2C10.5 6.9 12 5 14.9 5c1.2 0 2 .1 2 .1l-.1 2.6s-.8 0-1.6 0c-.8 0-1.2.4-1.2 1.1v2.5H17l-.2 2.7h-2.2Z"/></svg>
+                    </a>
+                    <a class="footer-social__link" href="#" aria-label="YouTube">
+                        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M21.6 7.2a2.5 2.5 0 0 0-1.7-1.8C18.2 5 12 5 12 5s-6.2 0-7.9.4A2.5 2.5 0 0 0 2.4 7.2C2 8.9 2 12 2 12s0 3.1.4 4.8a2.5 2.5 0 0 0 1.7 1.8C5.8 19 12 19 12 19s6.2 0 7.9-.4a2.5 2.5 0 0 0 1.7-1.8C22 15.1 22 12 22 12s0-3.1-.4-4.8ZM10 15.3V8.7l5.2 3.3Z"/></svg>
                     </a>
                 </div>
             </div>
-        </div>
-
-        <div class="footer-copyright" role="contentinfo">
-            © 2006-<?php echo date('Y'); ?> Nano Design Build
         </div>
     </div>
 </footer>

--- a/style.css
+++ b/style.css
@@ -143,13 +143,14 @@ body > footer {
 
 .footer-grid {
   display: grid;
-  grid-template-columns: minmax(0, 1.3fr) minmax(0, 1fr) auto;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   gap: 1.5rem clamp(1.75rem, 3vw, 2.75rem);
-  align-items: stretch;
+  align-items: center;
   text-align: left;
 }
 .footer-column { font-size: 14px; display: flex; flex-direction: column; gap: 0.65rem; }
 .footer-column--brand { font-size: 14px; gap: 0.55rem; }
+.footer-column--contact { justify-self: center; align-items: flex-start; }
 
 .footer-logo {
   max-height: 32px;

--- a/style.css
+++ b/style.css
@@ -35,6 +35,10 @@ body {
     padding: 0;
 }
 
+:root {
+    --brand-accent: #ff931e;
+}
+
 a {
     color: #1a1a1a;
     text-decoration: none;
@@ -125,7 +129,7 @@ body > footer {
 .site-footer {
   background: #0a0a0a;
   color: #e5e5e5;
-  padding: 3.5rem 2rem 2.75rem;
+  padding: 2.75rem 1.75rem 2.25rem;
   border-top: 1px solid #111;
 }
 
@@ -134,25 +138,24 @@ body > footer {
   margin: 0 auto;
   display: flex;
   flex-direction: column;
-  gap: 1.75rem;
+  gap: 1.25rem;
 }
 
 .footer-grid {
   display: grid;
   grid-template-columns: minmax(0, 1.3fr) minmax(0, 1fr) auto;
-  gap: 2rem clamp(2rem, 4vw, 3.25rem);
-  align-items: start;
+  gap: 1.5rem clamp(1.75rem, 3vw, 2.75rem);
+  align-items: stretch;
   text-align: left;
 }
-
-.footer-column { font-size: 14px; }
-.footer-column--brand { font-size: 14px; }
+.footer-column { font-size: 14px; display: flex; flex-direction: column; gap: 0.65rem; }
+.footer-column--brand { font-size: 14px; gap: 0.55rem; }
 
 .footer-logo {
   max-height: 32px;
   width: auto;
   display: block;
-  margin: 0 0 0.75rem;
+  margin: 0 0 0.5rem;
 }
 
 .footer-logo-link:hover { opacity: 0.85; }
@@ -170,9 +173,9 @@ body > footer {
 .footer-contact {
   list-style: none;
   padding: 0;
-  margin: 0 0 1.25rem;
+  margin: 0;
   display: grid;
-  gap: 0.5rem;
+  gap: 0.35rem;
 }
 
 .footer-contact__line { line-height: 1.5; color: #e5e5e5; }
@@ -189,21 +192,20 @@ body > footer {
 
 .footer-social {
   display: flex;
-  gap: 12px;
+  gap: 10px;
   align-items: center;
   justify-content: flex-end;
-  padding-top: 4px;
 }
 
 .footer-social__link {
   display: grid;
   place-items: center;
-  width: 38px;
-  height: 38px;
+  width: 34px;
+  height: 34px;
   border-radius: 50%;
   border: 1px solid rgba(255,147,30,.35);
   background: rgba(255,147,30,.08);
-  color: #ff931e;
+  color: var(--brand-accent);
   text-decoration: none;
   transition: transform .15s ease, border-color .2s ease, background .2s ease;
 }
@@ -236,6 +238,7 @@ body > footer {
   .footer-column--contact,
   .footer-column--social {
     text-align: center;
+    align-items: center;
   }
 
   .footer-logo {
@@ -251,14 +254,15 @@ body > footer {
 }
 
 .footer-copyright {
-  margin-top: 0.5rem;
-  padding-top: 1.25rem;
-  border-top: 1px solid rgba(255,255,255,.08);
+  margin-top: auto;
   font-size: 13px;
   color: #cfcfcf;
-  text-align: center;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.35rem;
 }
 
+.footer-copyright__symbol { color: var(--brand-accent); font-weight: 600; }
 
 /* ---------------------------
    Header: defaults (ALL pages)


### PR DESCRIPTION
## Summary
- Reworked the footer grid so the logo and accented copyright sit in the left column, contact details center, and LinkedIn/Instagram/Facebook/YouTube icons on the right
- Tightened footer spacing and applied the brand accent variable to icons and the copyright symbol while improving responsive alignment
- Documented the refreshed footer layout and #ff931e accent usage in the README

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935688557288320a468a6391c426b9a)